### PR TITLE
Idle events for non-disposed projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # AMII Changelog
 
 ## [Unreleased]
+
 ### Added
 
 ### Changed
@@ -13,7 +14,10 @@
 
 ### Fixed
 
+- Issue with attempting to display idle notifications on disposed projects
+
 ### Security
+
 ## [0.2.0]
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ platformVersion = 2020.3.1
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java,com.jetbrains.php:203.4449.22
-platformPlugins = io.acari.DDLCTheme:11.3.1
+platformPlugins = io.acari.DDLCTheme:12.1.1

--- a/src/main/kotlin/io/unthrottled/amii/tools/Debouncer.kt
+++ b/src/main/kotlin/io/unthrottled/amii/tools/Debouncer.kt
@@ -35,6 +35,7 @@ class AlarmDebouncer<T>(
           buffer.add(t)
           onDebounced(buffer.toMutableList())
           buffer.clear()
+          previousOnDebounce = null
         },
         interval
       )
@@ -54,6 +55,7 @@ class AlarmDebouncer<T>(
   }
 
   override fun dispose() {
+    previousOnDebounce = null
     alarm.dispose()
   }
 }


### PR DESCRIPTION
# Changes
- Bump Doki version to 12.1.1
- Debouncing is hard, cleaning up correctly after debounce.

# Motivation

Closes #14
