### PR TITLE
Error submission confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Removed
 
 ### Fixed
+- Confirming when an error is submitted.
 
 - Issue with attempting to display idle notifications on disposed projects
 


### PR DESCRIPTION
# Details
- Confirming submission when reporting errors, so that it show `Submitted` when the exception window is opened again.

# Motivation

Closes #15
