### PR TITLE
Updates for Waifu Motivator users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # AMII Changelog
 
+## [0.5.1]
+
+### Changed
+
+- The Highest supported version to be `211.*`
+- Plugin's primary name to `Anime Memes` to help not confuse [Waifu Motivator](https://plugins.jetbrains.com/plugin/13381-waifu-motivator) users.
+
 ## [0.5.0]
 
 - Addressed fatal legacy platform issues.

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Available for any [JetBrains IDE](https://github.com/doki-theme/doki-theme-jetbr
 
 <p align="center"><img src="https://raw.githubusercontent.com/waifu-motivator/waifu-motivator-plugin/master/images/wmp_logo.png" height="256px" alt="Waifu Motivator Plugin Logo"></p>
 
-<p align="center">An open-sourced Jetbrains IDE plugin that brings your <i>Waifu</i> in to help keep your motivation to complete during your coding challenges.</p>
+<p align="center">A collection of open-sourced Jetbrains IDE plugins that bring <i>Waifus</i> in to help keep your motivation to complete during your coding challenges.</p>
 
 
 ## Want AMII updates sooner?

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
     <img style="max-height: 256px" src="https://waifu.assets.unthrottled.io/visuals/amused/aqua_amused.gif" ></img>
 </div>
 
-# AMII
+# AMII (Anime Meme IDE Integration)
 
 ![Build](https://github.com/Unthrottled/AMII/workflows/Build/badge.svg)
 [![Version](https://img.shields.io/jetbrains/plugin/v/15865-amii.svg)](https://plugins.jetbrains.com/plugin/15865-amii)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/15865-amii.svg)](https://plugins.jetbrains.com/plugin/15865-amii)
 
 <!-- Plugin description -->
-Give your IDE more personality and have <emphasis>more</emphasis> fun programming with the **A**nime **M**eme **I**DE **I**ntegration!<br/><br/>
+Give your IDE more personality and have <emphasis>more</emphasis> fun programming with the **A**nime **M**eme **I**DE **I**ntegration! (AMII)<br/><br/>
 Upon installation, our Meme Inference Knowledge Unit (or MIKU for short)
 will begin interact with you as you build code.
 MIKU knows when your programs fail to run or tests pass/fail.
 Your new companion has the ability to react to these events.
-Which will most likely take the form of an anime meme of your favorite character(s)!<br/><br/>
+Which will most likely take the form of an anime meme of your: waifu, husbando, and/or favorite character(s)!<br/><br/>
 
 <!-- Plugin description end -->
 
@@ -22,7 +22,7 @@ Which will most likely take the form of an anime meme of your favorite character
 
 - Using IDE built-in plugin system:
 
-  <kbd>Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>Marketplace</kbd> > <kbd>Search for "AMII"</kbd> >
+  <kbd>Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>Marketplace</kbd> > <kbd>Search for "Anime Memes"</kbd> >
   <kbd>Install Plugin</kbd>
 
 - Manually:
@@ -56,6 +56,7 @@ Which will most likely take the form of an anime meme of your favorite character
     - [Asset View](#asset-view)
 - [Extras](#extras)
   - [The Doki Theme](#the-doki-theme)
+  - [Waifu Motivator](#the-doki-theme)
   - [Release Channel](#want-amii-updates-sooner)
 - [Attributions](#attributions)
 ---
@@ -356,6 +357,13 @@ Decorate all your favorite tools with your favorite character(s)!
 Available for any [JetBrains IDE](https://github.com/doki-theme/doki-theme-jetbrains).
 
 ![Doki Theme Jetbrains](https://github.com/doki-theme/doki-theme-jetbrains/raw/master/assets/screenshots/flagship_themes.gif)
+
+
+## Waifu Motivator
+
+<p align="center"><img src="https://raw.githubusercontent.com/waifu-motivator/waifu-motivator-plugin/master/images/wmp_logo.png" height="256px" alt="Waifu Motivator Plugin Logo"></p>
+
+<p align="center">An open-sourced Jetbrains IDE plugin that brings your <i>Waifu</i> in to help keep your motivation to complete during your coding challenges.</p>
 
 
 ## Want AMII updates sooner?

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = io.unthrottled
-pluginName_ = AMII
-pluginVersion = 0.5.0
+pluginName_ = Anime Memes
+pluginVersion = 0.5.1
 pluginSinceBuild = 202.6397.94
-pluginUntilBuild = 203.*
+pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions = 2020.2.2, 2020.2.3, 2020.3

--- a/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
@@ -23,10 +23,11 @@ private fun buildUpdateMessage(updateAsset: String): String =
   """
       What's New?<br>
       <ul>
-        <li>Initial Release! See the <a href="https://github.com/Unthrottled/AMII#documentation">
-      documentation</a> for features, usages, and configurations.</li>
+        <li>Changed plugin's primary name to "Anime Memes". (Still referred to as "AMII" in the plugin)</li>
       </ul>
-      <br>Please see the <a href="https://github.com/Unthrottled/AMII/blob/master/CHANGELOG.md">changelog</a> for more details.
+      Welcome <a href='https://plugins.jetbrains.com/plugin/13381-waifu-motivator'>Waifu Motivator</a> users! ❤️<br>
+      <br>See the <a href="https://github.com/Unthrottled/AMII#documentation">documentation</a> for features, usages, and configurations.
+      <br>The <a href="https://github.com/Unthrottled/AMII/blob/master/CHANGELOG.md">changelog</a> is available for more details.
       <br><br>
       <div style='text-align: center'><img alt='Thanks for downloading!' src="$updateAsset"
       width='256'><br/><br/><br/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
   <id>io.unthrottled.amii</id>
-  <name>AMII</name>
+  <name>Anime Memes</name>
   <vendor>Unthrottled</vendor>
 
   <!-- Product and plugin compatibility requirements -->


### PR DESCRIPTION
# Changes

- The Highest supported version to be `211.*`
- Plugin's primary name to `Anime Memes` to help not confuse [Waifu Motivator](https://plugins.jetbrains.com/plugin/13381-waifu-motivator) users.

# Motivation

Mirrors the plugin build for the Waifu Motivator plugin.
I also don't want to confuse the Waifu Motivator users by requiring them to install `AMII` without knowing what the abbreviation stands for.

Supports https://github.com/waifu-motivator/waifu-motivator-plugin/pull/289


