### PR TITLE
Focus loss with project context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # AMII Changelog
 
+## [0.5.1]
+
+### Changed
+
+- How the AFK gifs are dismissed. They only get dismissed when the project it is on gains focus again. Not when any project gains focus.
+
 ## [0.5.2]
 
 ### Fixed

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,3 +1,2 @@
-- Not being able to set frustration probability
-- Not being able to disable sound
-- The idle meme display position and meme display being persisted incorrectly.
+### Changed
+- How the AFK gifs are dismissed. They only get dismissed when the project it is on gains focus again. Not when any project gains focus.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
-pluginVersion = 0.5.2
+pluginVersion = 0.5.3
 pluginSinceBuild = 202.6397.94
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
@@ -159,7 +159,7 @@ class MemePanel(
       val isFocusLoss = memePanelSettings.dismissal == FOCUS_LOSS
       if (e is MouseEvent) {
         val wasInside = isInsideMemePanel(e)
-        val wasInsideProject = isInsideRootPane(e)
+        val wasInsideProject = UIUtil.isDescendingFrom(e.component, rootPane)
         if (e.id == MouseEvent.MOUSE_PRESSED) {
           val wasClickedOutsideProject = !wasInside && wasInsideProject && isFocusLoss
           if (wasClickedOutsideProject || clickedInside) {
@@ -174,6 +174,7 @@ class MemePanel(
       ) {
         if (
           isFocusLoss &&
+          UIUtil.isDescendingFrom(e.component, rootPane) &&
           ALLOWED_KEYS.contains(e.keyCode).not()
         ) {
           dismissMeme()
@@ -233,9 +234,6 @@ class MemePanel(
 
   private fun isInsideMemePanel(e: MouseEvent): Boolean =
     isInsideComponent(e, this)
-
-  private fun isInsideRootPane(e: MouseEvent): Boolean =
-    isInsideComponent(e, rootPane)
 
   private fun isInsideComponent(e: MouseEvent, rootPane1: JComponent): Boolean {
     val target = RelativePoint(e)


### PR DESCRIPTION
## Motivation

Allows memes set to the `Focus Loss` dismissal option to be dismissed only when focus is lost in the project it originated from.
In other words, AFK gifs from other open projects don't go away when you come back to an unrelated project.

Probably what #68 wants

