### PR TITLE
Fixed idle event triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # AMII Changelog
 
+## [0.7.2]
+
+### Fixed
+
+- The issue with the idle notifications not coming up even after not clicking/typing in the project.
+
 ## [0.7.1]
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
-pluginVersion = 0.7.1
+pluginVersion = 0.7.2
 pluginSinceBuild = 202.6397.94
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl


### PR DESCRIPTION
### Fixed

- The issue with the idle notifications not coming up even after not clicking/typing in the project.

Related issue #68
