### PR TITLE
Many Small Bug Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 # AMII Changelog
 
+## [0.8.1]
+
+### Fixed
+- MIKU attempting to react on a project that is disposed (again...).
+- Actually addressing the sound playback errors on Linux
+- Attempting to cool down a MIKU from a disposed project.
+- MIKU not paying attention to the relax action.
+
+### Changed
+- Memes with sound only play as long as the sound clip (when sound is enabled).
+
 ## [0.8.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Decorate all your favorite tools with your favorite character(s)!
 
 Available for any [JetBrains IDE](https://github.com/doki-theme/doki-theme-jetbrains).
 
-![Doki Theme Jetbrains](https://github.com/doki-theme/doki-theme-jetbrains/raw/master/assets/screenshots/flagship_themes.gif)
+![Doki Theme Jetbrains](https://github.com/doki-theme/doki-theme-jetbrains/raw/master/assets/screenshots/themes.webp)
 
 
 ## Waifu Motivator

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -3,3 +3,10 @@
   [See the updated documentation for more details.](https://github.com/Unthrottled/AMII#exit-codes)
 
 ### Fixed
+- MIKU attempting to react on a project that is disposed (again...).
+- Actually addressing the sound playback errors on Linux
+- Attempting to cool down a MIKU from a disposed project.
+- MIKU not paying attention to the relax action.
+
+### Changed
+- Memes with sound only play as long as the sound clip (when sound is enabled).

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
-pluginVersion = 0.8.0
+pluginVersion = 0.8.1
 pluginSinceBuild = 202.6397.94
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/io/unthrottled/amii/core/MIKU.kt
+++ b/src/main/kotlin/io/unthrottled/amii/core/MIKU.kt
@@ -119,6 +119,8 @@ class MIKU(private val project: Project) :
   }
 
   override fun onAction(emotionalMutationAction: EmotionalMutationAction) {
+    if(emotionalMutationAction.project?.isDisposed == true) return
+
     val mutatedMood = emotionCore.mutateMood(emotionalMutationAction)
     reactToMutation(emotionalMutationAction)
     publishMood(mutatedMood)

--- a/src/main/kotlin/io/unthrottled/amii/core/MIKU.kt
+++ b/src/main/kotlin/io/unthrottled/amii/core/MIKU.kt
@@ -119,7 +119,7 @@ class MIKU(private val project: Project) :
   }
 
   override fun onAction(emotionalMutationAction: EmotionalMutationAction) {
-    if(emotionalMutationAction.project?.isDisposed == true) return
+    if (emotionalMutationAction.project?.isDisposed == true) return
 
     val mutatedMood = emotionCore.mutateMood(emotionalMutationAction)
     reactToMutation(emotionalMutationAction)

--- a/src/main/kotlin/io/unthrottled/amii/core/MIKU.kt
+++ b/src/main/kotlin/io/unthrottled/amii/core/MIKU.kt
@@ -58,11 +58,12 @@ class MIKU(private val project: Project) :
   private val singleEventDebouncer = AlarmDebouncer<UserEvent>(DEBOUNCE_INTERVAL)
   private val idleEventDebouncer = AlarmDebouncer<UserEvent>(DEBOUNCE_INTERVAL)
   private val messageBusConnection = ApplicationManager.getApplication().messageBus.connect()
+  private val projectMessageBusConnection = project.messageBus.connect()
 
   init {
     ApplicationManager.getApplication().invokeLater {
-      attemptToSubscribe { messageBusConnection.subscribe(EMOTION_TOPIC, this) }
-      attemptToSubscribe { messageBusConnection.subscribe(EMOTIONAL_MUTATION_TOPIC, this) }
+      attemptToSubscribe { projectMessageBusConnection.subscribe(EMOTION_TOPIC, this) }
+      attemptToSubscribe { projectMessageBusConnection.subscribe(EMOTIONAL_MUTATION_TOPIC, this) }
       attemptToSubscribe {
         messageBusConnection.subscribe(
           CONFIG_TOPIC,
@@ -165,5 +166,6 @@ class MIKU(private val project: Project) :
     singleEventDebouncer.dispose()
     idleEventDebouncer.dispose()
     messageBusConnection.dispose()
+    projectMessageBusConnection.dispose()
   }
 }

--- a/src/main/kotlin/io/unthrottled/amii/core/ModalityProcessor.kt
+++ b/src/main/kotlin/io/unthrottled/amii/core/ModalityProcessor.kt
@@ -9,6 +9,8 @@ class ModalityProcessor(private val config: Config) {
   private var lastSeenUserEvent: UserEvent? = null
 
   fun shouldProcess(userEvent: UserEvent): Boolean {
+    if(userEvent.project.isDisposed) return false
+
     val shouldReact = shouldReact(userEvent)
     lastSeenUserEvent = userEvent
     return shouldReact

--- a/src/main/kotlin/io/unthrottled/amii/core/ModalityProcessor.kt
+++ b/src/main/kotlin/io/unthrottled/amii/core/ModalityProcessor.kt
@@ -9,7 +9,7 @@ class ModalityProcessor(private val config: Config) {
   private var lastSeenUserEvent: UserEvent? = null
 
   fun shouldProcess(userEvent: UserEvent): Boolean {
-    if(userEvent.project.isDisposed) return false
+    if (userEvent.project.isDisposed) return false
 
     val shouldReact = shouldReact(userEvent)
     lastSeenUserEvent = userEvent

--- a/src/main/kotlin/io/unthrottled/amii/core/personality/emotions/CoolDownCore.kt
+++ b/src/main/kotlin/io/unthrottled/amii/core/personality/emotions/CoolDownCore.kt
@@ -40,8 +40,12 @@ class CoolDownCore(private val project: Project) : MoodListener, Disposable {
   }
 
   private fun registerCoolDownEvent() {
+    if (project.isDisposed) return
+
     coolDownAlarm.addRequest(
       {
+        if (project.isDisposed) return@addRequest
+
         project.messageBus
           .syncPublisher(EMOTIONAL_MUTATION_TOPIC)
           .onAction(EmotionalMutationAction(COOL_DOWN, NEGATIVE))

--- a/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
@@ -51,7 +51,6 @@ import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import java.awt.image.BufferedImage
 import java.awt.image.RGBImageFilter
-import java.lang.Long.max
 import javax.swing.JComponent
 import javax.swing.JLayeredPane
 import javax.swing.JPanel
@@ -454,14 +453,15 @@ class MemePanel(
   private fun getMemeDuration(): Int {
     val memeDisplayDuration = memePanelSettings.displayDuration * TENTH_OF_A_SECOND_MULTIPLICAND
     return if (visualMeme.filePath.toString().endsWith(".gif", ignoreCase = true)) {
-      val duration = max(
-        GifService.getDuration(visualMeme.filePath).toLong(),
-        memePlayer?.duration ?: MemePlayer.NO_LENGTH
-      ).toInt()
-      if (duration < memeDisplayDuration) {
-        duration * (memeDisplayDuration / duration)
+      if (memePlayer != null) {
+        memePlayer.duration.toInt()
       } else {
-        duration
+        val duration = GifService.getDuration(visualMeme.filePath)
+        if (duration < memeDisplayDuration) {
+          duration * (memeDisplayDuration / duration)
+        } else {
+          duration
+        }
       }
     } else {
       memeDisplayDuration

--- a/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
@@ -453,7 +453,7 @@ class MemePanel(
   private fun getMemeDuration(): Int {
     val memeDisplayDuration = memePanelSettings.displayDuration * TENTH_OF_A_SECOND_MULTIPLICAND
     return if (visualMeme.filePath.toString().endsWith(".gif", ignoreCase = true)) {
-      if (memePlayer != null) {
+      if (memePlayer != null && memePlayer.duration > 0) {
         memePlayer.duration.toInt()
       } else {
         val duration = GifService.getDuration(visualMeme.filePath)

--- a/src/main/kotlin/io/unthrottled/amii/memes/player/ClipSoundPlayer.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/player/ClipSoundPlayer.kt
@@ -50,8 +50,8 @@ class ClipSoundPlayer(
       }
 
   init {
-    val gainControl = clip?.getControl(FloatControl.Type.MASTER_GAIN) as FloatControl
-    gainControl.value = DECIBEL_MULTIPLICAND * log10(Config.instance.volume)
+    val gainControl = clip?.getControl(FloatControl.Type.MASTER_GAIN) as? FloatControl
+    gainControl?.value = DECIBEL_MULTIPLICAND * log10(Config.instance.volume)
   }
 
   override val duration: Long

--- a/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
@@ -24,6 +24,9 @@ private fun buildUpdateMessage(updateAsset: String): String =
       What's New?<br>
       <ul>
         <li>MIKU can positively react to exit codes.</li>
+        <li>Memes with sound duration.</li>
+        <li>Handling Sound playback bugs on Linux better (for real this time).</li>
+        <li>Handling disposed projects better.</li>
       </ul>
       <br>See the <a href="https://github.com/Unthrottled/AMII#documentation">documentation</a> for features, usages, and configurations.
       <br>The <a href="https://github.com/Unthrottled/AMII/blob/master/CHANGELOG.md">changelog</a> is available for more details.


### PR DESCRIPTION
### Fixed
- MIKU attempting to react on a project that is disposed (again...).
- Actually addressing the sound playback errors on Linux
- Attempting to cool down a MIKU from a disposed project.
- MIKU not paying attention to the relax action.

### Changed
- Memes with sound only play as long as the sound clip (when sound is enabled).

