### PR TITLE
IDE HTTP proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # AMII Changelog
 
+## [0.9.0]
+
+## Fixed
+
+- Plugin not working when the IDE is configured to use an HTTP proxy.
+
 ## [0.8.2]
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,7 @@ tasks {
     // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
     pluginDescription(
       closure {
-        File("./README.md").readText().lines().run {
+        File("${project.projectDir}/README.md").readText().lines().run {
           val start = "<!-- Plugin description -->"
           val end = "<!-- Plugin description end -->"
 
@@ -127,7 +127,7 @@ tasks {
 
     changeNotes(
       closure {
-        markdownToHTML(File("./docs/RELEASE-NOTES.md").readText())
+        markdownToHTML(File("${project.projectDir}/docs/RELEASE-NOTES.md").readText())
       }
     )
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
-pluginVersion = 0.8.2
+pluginVersion = 0.9.0
 pluginSinceBuild = 202.6397.94
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/io/unthrottled/amii/assets/AssetAPI.kt
+++ b/src/main/kotlin/io/unthrottled/amii/assets/AssetAPI.kt
@@ -1,8 +1,10 @@
 package io.unthrottled.amii.assets
 
+import com.intellij.openapi.application.ApplicationManager
 import io.unthrottled.amii.integrations.RestTools
 import java.io.InputStream
 import java.util.Optional
+import java.util.concurrent.Callable
 
 object AssetAPI {
   private val API_URL = System.getenv().getOrDefault(
@@ -13,8 +15,13 @@ object AssetAPI {
   fun <T> getAsset(
     path: String,
     bodyExtractor: (InputStream) -> T
-  ): Optional<T> = RestTools.performRequest(
-    "$API_URL$path",
-    bodyExtractor
-  )
+  ): Optional<T> =
+    ApplicationManager.getApplication().executeOnPooledThread(
+      Callable {
+        RestTools.performRequest(
+          "$API_URL$path",
+          bodyExtractor
+        )
+      }
+    ).get()
 }

--- a/src/main/kotlin/io/unthrottled/amii/assets/LocalContentService.kt
+++ b/src/main/kotlin/io/unthrottled/amii/assets/LocalContentService.kt
@@ -1,19 +1,10 @@
 package io.unthrottled.amii.assets
 
-import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.util.text.StringUtil
 import io.unthrottled.amii.assets.AssetCheckService.getCheckedDate
 import io.unthrottled.amii.assets.AssetCheckService.hasBeenCheckedToday
 import io.unthrottled.amii.assets.AssetCheckService.writeCheckedDate
-import io.unthrottled.amii.integrations.RestClient
 import java.nio.file.Files
 import java.nio.file.Path
-import java.security.MessageDigest
-import java.util.Optional
-
-private enum class AssetChangedStatus {
-  SAME, DIFFERENT, LUL_DUNNO
-}
 
 enum class AssetStatus {
   NOT_DOWNLOADED, STALE, CURRENT
@@ -25,17 +16,10 @@ data class AssetCheckPayload(
 )
 
 object LocalContentService {
-  private val log = Logger.getInstance(this::class.java)
-
   fun hasAssetChanged(
     localInstallPath: Path,
-    remoteAssetUrl: String
   ): Boolean =
-    !Files.exists(localInstallPath) ||
-      (
-        !hasBeenCheckedToday(localInstallPath) &&
-          isLocalDifferentFromRemote(localInstallPath, remoteAssetUrl) == AssetChangedStatus.DIFFERENT
-        )
+    !Files.exists(localInstallPath)
 
   fun hasAPIAssetChanged(
     localInstallPath: Path,
@@ -52,39 +36,4 @@ object LocalContentService {
       }
       else -> AssetCheckPayload(AssetStatus.CURRENT)
     }
-
-  private fun getOnDiskCheckSum(localAssetPath: Path): String =
-    computeCheckSum(Files.readAllBytes(localAssetPath))
-
-  private fun computeCheckSum(byteArray: ByteArray): String {
-    val messageDigest = MessageDigest.getInstance("MD5")
-    messageDigest.update(byteArray)
-    return StringUtil.toHexString(messageDigest.digest())
-  }
-
-  private fun getRemoteAssetChecksum(remoteAssetUrl: String): Optional<String> =
-    RestClient.performGet("$remoteAssetUrl.checksum.txt")
-
-  private fun isLocalDifferentFromRemote(
-    localInstallPath: Path,
-    remoteAssetUrl: String
-  ): AssetChangedStatus =
-    getRemoteAssetChecksum(remoteAssetUrl)
-      .map {
-        writeCheckedDate(localInstallPath)
-        val onDiskCheckSum = getOnDiskCheckSum(localInstallPath)
-        if (it == onDiskCheckSum) {
-          AssetChangedStatus.SAME
-        } else {
-          log.warn(
-            """
-                      Local asset: $localInstallPath
-                      is different from remote asset $remoteAssetUrl
-                      Local Checksum: $onDiskCheckSum
-                      Remote Checksum: $it
-            """.trimIndent()
-          )
-          AssetChangedStatus.DIFFERENT
-        }
-      }.orElseGet { AssetChangedStatus.LUL_DUNNO }
 }

--- a/src/main/kotlin/io/unthrottled/amii/integrations/ErrorReporter.kt
+++ b/src/main/kotlin/io/unthrottled/amii/integrations/ErrorReporter.kt
@@ -27,17 +27,26 @@ import java.lang.management.ManagementFactory
 import java.text.SimpleDateFormat
 import java.util.Arrays
 import java.util.Properties
+import java.util.concurrent.Callable
 import java.util.stream.Collectors
 
 class ErrorReporter : ErrorReportSubmitter() {
   companion object {
     init {
       Sentry.init { options: SentryOptions ->
-        options.dsn = RestClient.performGet(
-          "https://jetbrains.assets.unthrottled.io/amii/sentry-dsn.txt"
-        )
-          .map { it.trim() }
-          .orElse("https://9d45400dcf214fffb48f538e571781b4@o403546.ingest.sentry.io/5561788?maxmessagelength=50000")
+        options.dsn =
+          ApplicationManager.getApplication().executeOnPooledThread(
+            Callable {
+              RestClient.performGet(
+                "https://jetbrains.assets.unthrottled.io/amii/sentry-dsn.txt"
+              )
+                .map { it.trim() }
+                .orElse(
+                  "https://9d45400dcf214fffb48f538e571781b4@o403546" +
+                    ".ingest.sentry.io/5561788?maxmessagelength=50000"
+                )
+            }
+          ).get()
       }
       Sentry.setUser(
         User().apply {

--- a/src/main/kotlin/io/unthrottled/amii/integrations/RestClient.kt
+++ b/src/main/kotlin/io/unthrottled/amii/integrations/RestClient.kt
@@ -1,15 +1,12 @@
 package io.unthrottled.amii.integrations
 
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.io.HttpRequests
 import io.unthrottled.amii.integrations.RestTools.performRequest
 import io.unthrottled.amii.tools.readAllTheBytes
 import io.unthrottled.amii.tools.toOptional
-import org.apache.http.client.config.RequestConfig
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.impl.client.HttpClients
 import java.io.InputStream
 import java.util.Optional
-import java.util.concurrent.TimeUnit
 
 object RestClient {
 
@@ -20,42 +17,23 @@ object RestClient {
 }
 
 object RestTools {
-  private val httpClient = HttpClients.createMinimal()
   private val log = Logger.getInstance(this::class.java)
-
-  private const val STATUS_OK = 200
-  private const val ALLOWED_CONNECTION_TIMEOUT = 5L
 
   fun <T> performRequest(
     url: String,
     bodyExtractor: (InputStream) -> T
   ): Optional<T> {
     log.info("Attempting to download remote asset: $url")
-    val request = createGetRequest(url)
-    return try {
-      val response = httpClient.execute(request)
-      val statusCode = response.statusLine.statusCode
-      log.info("Asset has responded for remote asset: $url with status code $statusCode")
-      if (statusCode == STATUS_OK) {
-        response.entity.content.use(bodyExtractor).toOptional()
-      } else {
-        log.warn("Asset request for $url responded with $response")
-        Optional.empty()
+    return HttpRequests.request(url)
+      .connect { request ->
+        try {
+          val body = bodyExtractor(request.inputStream)
+          log.info("Asset has responded for remote asset: $url")
+          body.toOptional()
+        } catch (e: HttpRequests.HttpStatusException) {
+          log.warn("Unable to get remote asset: $url for raisins", e)
+          Optional.empty<T>()
+        }
       }
-    } catch (e: Throwable) {
-      log.warn("Unable to get remote asset: $url for raisins", e)
-      Optional.empty<T>()
-    } finally {
-      request.releaseConnection()
-    }
-  }
-
-  fun createGetRequest(remoteUrl: String): HttpGet {
-    val remoteAssetRequest = HttpGet(remoteUrl)
-    remoteAssetRequest.addHeader("User-Agent", "Doki-Theme-Jetbrains")
-    remoteAssetRequest.config = RequestConfig.custom()
-      .setConnectTimeout(TimeUnit.MILLISECONDS.convert(ALLOWED_CONNECTION_TIMEOUT, TimeUnit.SECONDS).toInt())
-      .build()
-    return remoteAssetRequest
   }
 }

--- a/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
@@ -23,10 +23,7 @@ private fun buildUpdateMessage(updateAsset: String): String =
   """
       What's New?<br>
       <ul>
-        <li>MIKU can positively react to exit codes.</li>
-        <li>Memes with sound duration.</li>
-        <li>Handling Sound playback bugs on Linux better (for real this time).</li>
-        <li>Handling disposed projects better.</li>
+        <li>Added support for use behind HTTP proxy (maybe)</li>
       </ul>
       <br>See the <a href="https://github.com/Unthrottled/AMII#documentation">documentation</a> for features, usages, and configurations.
       <br>The <a href="https://github.com/Unthrottled/AMII/blob/master/CHANGELOG.md">changelog</a> is available for more details.


### PR DESCRIPTION
## Changes

1. Using the platform's HTTP API.
1. Removed remote asset update checks.

## Motivation

1. Potentially fixes #91 
1. Assets don't change, they only get removed and created as a new asset.

## Notes

I installed Squid on my Ubuntu box and ran with this configurations, and it appears to still work!

![Screenshot from 2021-03-27 07-25-57](https://user-images.githubusercontent.com/15972415/112722156-c937fd00-8ed5-11eb-96ef-265c26e31d3a.png)
