### PR TITLE
Fix Rider compatibility issues with meme display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # AMII Changelog
 
+## [1.6.1] - 2025-07-20
+
+### Fixed
+
+- Improved IDE frame detection for better Rider compatibility
+- Enhanced root pane acquisition with multiple fallback methods
+- Fixed meme display issues in JetBrains Rider
+
 ## [1.5.0]
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,20 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup=io.unthrottled
-pluginVersion=1.6.0
-pluginSinceBuild=251
+pluginVersion=1.6.1
+# Universal compatibility - supports both IntelliJ and Rider
+pluginSinceBuild=243.21565.193
 pluginUntilBuild=251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
+# Built for universal compatibility
 platformType = IU
 platformVersion = 2025.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
-platformPlugins = Dart:251.23774.318,io.flutter:85.2.4
+# Removed Flutter dependency to prevent Rider conflicts
+# platformPlugins = Dart:251.23774.318,io.flutter:85.2.4
+platformPlugins = 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins =  NodeJS
 

--- a/src/main/kotlin/io/unthrottled/amii/tools/BalloonTools.kt
+++ b/src/main/kotlin/io/unthrottled/amii/tools/BalloonTools.kt
@@ -24,5 +24,7 @@ object BalloonTools {
     (
       WindowManager.getInstance().getIdeFrame(project)
         ?: WindowManager.getInstance().allProjectFrames.firstOrNull()
+        ?: WindowManager.getInstance().allProjectFrames.find { it.project == project }
+        ?: WindowManager.getInstance().allProjectFrames.find { it.project != null }
       ).toOptional()
 }

--- a/src/main/kotlin/io/unthrottled/amii/tools/ProjectTools.kt
+++ b/src/main/kotlin/io/unthrottled/amii/tools/ProjectTools.kt
@@ -1,8 +1,54 @@
 package io.unthrottled.amii.tools
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.WindowManager
 import com.intellij.util.ui.UIUtil
+import javax.swing.JLayeredPane
 
-fun Project.getRootPane() = UIUtil.getRootPane(
-  BalloonTools.getIDEFrame(this).orElse(null)?.component
-)?.layeredPane
+fun Project.getRootPane(): JLayeredPane? {
+  // Try multiple approaches to get the root pane
+  
+  // Approach 1: Original method via BalloonTools
+  val originalResult = UIUtil.getRootPane(
+    BalloonTools.getIDEFrame(this).orElse(null)?.component
+  )?.layeredPane
+  
+  if (originalResult != null) {
+    return originalResult
+  }
+  
+  // Approach 2: Direct WindowManager approach
+  val windowManager = WindowManager.getInstance()
+  
+  // Try getting frame directly for this project
+  var ideFrame = windowManager.getIdeFrame(this)
+  if (ideFrame != null) {
+    val rootPane = UIUtil.getRootPane(ideFrame.component)?.layeredPane
+    if (rootPane != null) return rootPane
+  }
+  
+  // Try getting any project frame
+  val allFrames = windowManager.allProjectFrames
+  for (frame in allFrames) {
+    if (frame.project == this) {
+      val rootPane = UIUtil.getRootPane(frame.component)?.layeredPane
+      if (rootPane != null) return rootPane
+    }
+  }
+  
+  // Try any frame with a project
+  for (frame in allFrames) {
+    if (frame.project != null) {
+      val rootPane = UIUtil.getRootPane(frame.component)?.layeredPane
+      if (rootPane != null) return rootPane
+    }
+  }
+  
+  // Last resort - try any frame at all
+  for (frame in allFrames) {
+    val rootPane = UIUtil.getRootPane(frame.component)?.layeredPane
+    if (rootPane != null) return rootPane
+  }
+  
+  return null
+}


### PR DESCRIPTION
- Enhanced IDE frame detection in BalloonTools with multiple fallback methods
- Improved root pane acquisition in ProjectTools with comprehensive fallback logic
- Fixed meme display functionality specifically for JetBrains Rider environments
- Version bump to 1.6.1
- Support for Rider 2024.3+